### PR TITLE
Support trailingSlash option in docusaurus.config.js

### DIFF
--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -1,6 +1,8 @@
 const assert = require('assert')
+const path = require('path')
 const utils = require('../utils')
 
+const outDir = '/out'
 const baseUrl = 'http://example.com/'
 
 describe('utils', () => {
@@ -15,7 +17,7 @@ describe('utils', () => {
       `${baseUrl}docs/changelogs/rovers/lunar`,
     ]
 
-    const [files, meta] = utils.getFilePaths(routesPaths, '/out', baseUrl, {
+    const [files, meta] = utils.getFilePaths(routesPaths, outDir, baseUrl, {
       excludeRoutes: ['docs/changelogs/**/*']
     })
 
@@ -28,5 +30,17 @@ describe('utils', () => {
     ])
 
     assert.equal(meta.excludedCount, 2)
+  })
+
+  it('should handle paths generated when using docusaurus.config.js `trailingSlash` option', () => {
+    const routesPaths = [
+      `${baseUrl}docs/tutorial/overview/`,
+    ]
+
+    const [files] = utils.getFilePaths(routesPaths, outDir, baseUrl)
+
+    assert.deepEqual(files.map(f => f.path), [
+      path.join(outDir, 'docs/tutorial/overview/index.html')
+    ])
   })
 })

--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -2,18 +2,19 @@ const assert = require('assert')
 const utils = require('../utils')
 
 const baseUrl = 'http://example.com/'
-const routesPaths = [
-  `${baseUrl}docs/tutorial/overview`,
-  `${baseUrl}docs/tutorial/get-started`,
-  `${baseUrl}docs/how-to/add-plugin`,
-  `${baseUrl}docs/how-to/extract-value`,
-  `${baseUrl}docs/explanation/solar-sytem`,
-  `${baseUrl}docs/changelogs/index`,
-  `${baseUrl}docs/changelogs/rovers/lunar`,
-]
 
 describe('utils', () => {
-  it('should exlude routes by exludeRoutes globs', () => {
+  it('should not include routes matching globs provided in `excludeRoutes` options', () => {
+    const routesPaths = [
+      `${baseUrl}docs/tutorial/overview`,
+      `${baseUrl}docs/tutorial/get-started`,
+      `${baseUrl}docs/how-to/add-plugin`,
+      `${baseUrl}docs/how-to/extract-value`,
+      `${baseUrl}docs/explanation/solar-system`,
+      `${baseUrl}docs/changelogs/index`,
+      `${baseUrl}docs/changelogs/rovers/lunar`,
+    ]
+
     const [files, meta] = utils.getFilePaths(routesPaths, '/out', baseUrl, {
       excludeRoutes: ['docs/changelogs/**/*']
     })
@@ -23,7 +24,7 @@ describe('utils', () => {
       `docs/tutorial/get-started`,
       `docs/how-to/add-plugin`,
       `docs/how-to/extract-value`,
-      `docs/explanation/solar-sytem`,
+      `docs/explanation/solar-system`,
     ])
 
     assert.equal(meta.excludedCount, 2)

--- a/src/utils.js
+++ b/src/utils.js
@@ -62,18 +62,21 @@ function getFilePaths(routesPaths, outDir, baseUrl, options = {}) {
 
     routesPaths.forEach((route) => {
         if (route === `${baseUrl}404.html`) return
+
+        const isBaseUrl = route === baseUrl
         let filePath;
-        if (route === baseUrl) {
-            if (!indexBaseUrl) {
-                return;
-            }
-            // Special case for index.html
-            route = route.substr(baseUrl.length)
+
+        if (isBaseUrl && !indexBaseUrl) {
+            return;
+        }
+
+        route = route.substring(baseUrl.length)
+        if (isBaseUrl || route.endsWith(path.sep)) {
             filePath = path.join(outDir, route, "index.html")
         } else {
-            route = route.substr(baseUrl.length)
             filePath = path.join(outDir, `${route}.html`)
         }
+
         // In case docs only mode routesPaths has baseUrl twice
         if(addedFiles.has(filePath)) return
         if (excludeRoutes.some((excludePattern) => minimatch(route, excludePattern))) {


### PR DESCRIPTION
When using the `trailingSlash` option with `true` value, Docusaurus will generate `index.html` files for each page. 
This change makes sure such pages will be indexed by Lunr.

Addresses remaining issue for https://github.com/praveenn77/docusaurus-lunr-search/issues/77