### PR TITLE
Files not found when baseUrl is not `/`

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -69,10 +69,12 @@ function getFilePaths(routesPaths, outDir, baseUrl, options = {}) {
             return;
         }
 
-        const candidatePaths = [
-            path.join(outDir, `${route}.html`),
-            path.join(outDir, route, "index.html")
-        ]
+        const candidatePaths = [route, route.substring(baseUrl.length)].flatMap(route => {
+            return [
+                path.join(outDir, `${route}.html`),
+                path.join(outDir, route, "index.html")
+            ]
+        });
 
         const filePath = candidatePaths.find(fs.existsSync);
         if(!fs.existsSync(filePath)) {


### PR DESCRIPTION
The following assumes a default `--out-dir` of `build`.

Assume a single file: `docs/intro.md`. when building with docusaurus 2.0, you get `build/docs/intro/index.html`

When you use `/` as the baseUrl, which is the default, the previous code works correctly.

When you use `/some-thing/` as the base url, your docs are still written to `build`, yet the `route` received will be: `/some-thing/docs/intro/index.html`. This route, appended with the outputDir will result in `build/some-thing/docs/intro/index.html` which does not exist.

This PR changes the path to look at depending on the baseUrl. If the default is used (`/`), then we use the route as is, otherwise, we drop the baseUrl from the `route` via substring.

-----

To reproduce,
1. follow the quickstart guide for docusaurus.
2. install lunr
3. build (it works)
4. change the baseUrl
5. build (it fails)
6. (optional) test this PR by updathing the file under `node_modules/docusaurus-lunr-search/src/utils.js` with the content of this PR and re-run

-----

```bash
$ cat docusaurus.config.js | grep baseUrl
  baseUrl: "/some-thing/",
$ # before the fix
$ npm run build

> my-website@0.0.0 build
> docusaurus build

[INFO] [en] Creating an optimized production build...

✔ Client
  

✔ Server
  Compiled successfully in 9.18s


✔ Client
  

● Server █████████████████████████ cache (99%) shutdown IdleFileCachePlugin
 stored

docusaurus-lunr-search:: Building search docs and lunr index file
docusaurus-lunr-search: could not resolve file for route '/some-thing/blog', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/blog/archive', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/blog/first-blog-post', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/blog/long-blog-post', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/blog/mdx-blog-post', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/blog/tags', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/blog/tags/docusaurus', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/blog/tags/facebook', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/blog/tags/hello', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/blog/tags/hola', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/blog/welcome', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/markdown-page', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/docs/category/tutorial---basics', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/docs/category/tutorial---extras', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/docs/intro', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/docs/tutorial-basics/congratulations', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/docs/tutorial-basics/create-a-blog-post', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/docs/tutorial-basics/create-a-document', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/docs/tutorial-basics/create-a-page', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/docs/tutorial-basics/deploy-your-site', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/docs/tutorial-basics/markdown-features', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/docs/tutorial-extras/manage-docs-versions', it will be missing in the search index
docusaurus-lunr-search: could not resolve file for route '/some-thing/docs/tutorial-extras/translate-your-site', it will be missing in the search index
docusaurus-lunr-search:: Start scanning documents in 1 threads
docusaurus-lunr-search:: unable to read file undefined
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at new NodeError (node:internal/errors:372:5)
    at validateString (node:internal/validators:120:11)
    at Object.resolve (node:path:1098:7)
    at Function.readSync (/private/tmp/my-website/node_modules/to-vfile/lib/sync.js:13:40)
    at scanDocuments (/private/tmp/my-website/node_modules/docusaurus-lunr-search/src/html-to-doc.js:18:21)
    at scanDocuments.next (<anonymous>)
    at processFile (/private/tmp/my-website/node_modules/docusaurus-lunr-search/src/html-to-doc.js:114:14)
    at MessagePort.<anonymous> (/private/tmp/my-website/node_modules/docusaurus-lunr-search/src/html-to-doc.js:123:5)
    at MessagePort.[nodejs.internal.kHybridDispatch] (node:internal/event_target:643:20)
    at MessagePort.exports.emitMessage (node:internal/per_context/messageport:23:28) {
  code: 'ERR_INVALID_ARG_TYPE'
}
docusaurus-lunr-search:: Indexing time: 58.139ms
docusaurus-lunr-search:: indexed 0 documents out of 1
docusaurus-lunr-search:: writing search-doc.json
docusaurus-lunr-search:: writing search-doc-1667325606022.json
docusaurus-lunr-search:: writing lunr-index.json
docusaurus-lunr-search:: writing lunr-index-1667325606022.json
docusaurus-lunr-search:: End of process
[SUCCESS] Generated static files in "build".
[INFO] Use `npm run serve` command to test your build locally.
```

```bash
$ # after the fix
$ npm run build

> my-website@0.0.0 build
> docusaurus build

[INFO] [en] Creating an optimized production build...

✔ Client
  

✔ Server
  Compiled successfully in 3.23s


✔ Client
  

● Server █████████████████████████ cache (99%) shutdown IdleFileCachePlugin
 stored

docusaurus-lunr-search:: Building search docs and lunr index file
docusaurus-lunr-search:: Start scanning documents in 10 threads
docusaurus-lunr-search:: Indexing time: 190.739ms
docusaurus-lunr-search:: indexed 13 documents out of 23
docusaurus-lunr-search:: writing search-doc.json
docusaurus-lunr-search:: writing search-doc-1667325663367.json
docusaurus-lunr-search:: writing lunr-index.json
docusaurus-lunr-search:: writing lunr-index-1667325663367.json
docusaurus-lunr-search:: End of process
[SUCCESS] Generated static files in "build".
[INFO] Use `npm run serve` command to test your build locally.
```