### PR TITLE
Avoid adding extra `/` on hits

### DIFF
--- a/src/theme/SearchBar/lunar-search.js
+++ b/src/theme/SearchBar/lunar-search.js
@@ -26,7 +26,7 @@ class LunrSearchAdapter {
                 lvl0: doc.pageTitle || doc.title,
                 lvl1: doc.type === 0 ? null : doc.title
             },
-            url: this.baseUrl !== '/' || doc.url.charAt(0) !== '/' ? this.baseUrl + doc.url : doc.url,
+            url: doc.url,
             _snippetResult: formattedContent ? {
                 content: {
                     value: formattedContent,


### PR DESCRIPTION
say we got doc.url = /docs/intro.html

with baseUrl = '/', the condition failed because doc.url starts with a `/`, so we returned `doc.url

with baseUrl = `/some-thing/`, the condition succeeds because baseUrl is not `/`, so we return the concatenated url, but it's wrong. it gives: `/some-thing//docs/intro.html`

The thing is that the doc.url already contains the baseUrl, so there is no need to concatenate.

Again running off the docusaurus getting started and applying the fix locally:

`baseUrl = /`:
<img width="864" alt="Screen Shot 2022-11-11 at 09 47 38" src="https://user-images.githubusercontent.com/5230460/201364569-6abb7baa-f99e-4d98-a713-9a4d671bfdea.png">

`baseUrl = /some-thing/`:
<img width="858" alt="Screen Shot 2022-11-11 at 09 48 35" src="https://user-images.githubusercontent.com/5230460/201364653-1dd98d33-a7ad-4e96-83fe-3d0f9df34a56.png">

This is a follow up to https://github.com/praveenn77/docusaurus-lunr-search/pull/89 and https://github.com/praveenn77/docusaurus-lunr-search/pull/88