### PR TITLE
Replace classnames with clsx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "autocomplete.js": "^0.37.0",
-        "classnames": "^2.2.6",
+        "clsx": "^1.2.1",
         "gauge": "^3.0.0",
         "hast-util-select": "^4.0.0",
         "hast-util-to-text": "^2.0.0",
@@ -4533,11 +4533,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
-    },
     "node_modules/clean-css": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.1.tgz",
@@ -4706,6 +4701,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/collapse-white-space": {
@@ -17314,11 +17317,6 @@
       "integrity": "sha512-up5ggbaDqOqJ4UqLKZ2naVkyqSJQgJi5lwD6b6mM748ysrghDBX0bx/qJTUHzw7zu6Mq4gycviSF5hJnwceD8w==",
       "peer": true
     },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
-    },
     "clean-css": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.1.tgz",
@@ -17448,6 +17446,11 @@
       "requires": {
         "mimic-response": "^1.0.0"
       }
+    },
+    "clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
     },
     "collapse-white-space": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "license": "MIT",
   "dependencies": {
     "autocomplete.js": "^0.37.0",
-    "classnames": "^2.2.6",
+    "clsx": "^1.2.1",
     "gauge": "^3.0.0",
     "hast-util-select": "^4.0.0",
     "hast-util-to-text": "^2.0.0",

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -6,7 +6,7 @@
  */
 
 import React, { useRef, useCallback, useState } from "react";
-import classnames from "classnames";
+import clsx from "clsx";
 import { useHistory } from "@docusaurus/router";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import { usePluginData } from '@docusaurus/useGlobalData';
@@ -90,7 +90,7 @@ const Search = props => {
       <span
         aria-label="expand searchbar"
         role="button"
-        className={classnames("search-icon", {
+        className={clsx("search-icon", {
           "search-icon-hidden": props.isSearchBarExpanded
         })}
         onClick={toggleSearchIconClick}
@@ -102,7 +102,7 @@ const Search = props => {
         type="search"
         placeholder={indexReady ? 'Search' : 'Loading...'}
         aria-label="Search"
-        className={classnames(
+        className={clsx(
           "navbar__search-input",
           { "search-bar-expanded": props.isSearchBarExpanded },
           { "search-bar": !props.isSearchBarExpanded }


### PR DESCRIPTION
# What?
I've replaced `classnames` library with `clsx`

# Why:
- docusaurus uses clsx: https://github.com/facebook/docusaurus/pull/2895
- as mentioned [here](https://github.com/facebook/docusaurus/pull/2895) - it is smaller and faster

