### PR TITLE
Add version display feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ module.exports = {
     ],
 }
 ```
+
+### disableVersioning
+Docs versions are displayed by default. If you want to hide it, set this plugin option to `true`
+
+
 Thanks to [`algolia/docsearch.js`](https://github.com/algolia/docsearch), I modified it to create this search component 
 
 And thanks [cmfcmf](https://github.com/cmfcmf), I used the code from his library [docusaurus-search-local](https://github.com/cmfcmf/docusaurus-search-local) for multi-language support.

--- a/src/html-to-doc.js
+++ b/src/html-to-doc.js
@@ -51,6 +51,16 @@ function* scanDocuments({ path, url }) {
     return acc
   }, []).join(' ')
 
+  let version = null;
+  if (workerData.loadedVersions) {
+    const docsearchVersionElement = select('meta[name="docsearch:version"]', hast);
+
+    version = docsearchVersionElement
+      ? workerData.loadedVersions[docsearchVersionElement.properties.content]
+      : null;
+  }
+
+
   yield {
     title: pageTitle,
     type: 0,
@@ -59,6 +69,7 @@ function* scanDocuments({ path, url }) {
     // If there is no sections then push the complete content under page title
     content: sectionHeaders.length === 0 ? getContent(markdown) : '',
     keywords,
+    version,
   }
 
   for (const sectionDesc of sectionHeaders) {
@@ -69,6 +80,7 @@ function* scanDocuments({ path, url }) {
       pageTitle,
       url: `${url}#${ref}`,
       content,
+      version,
     }
   }
 }

--- a/src/theme/SearchBar/DocSearch.js
+++ b/src/theme/SearchBar/DocSearch.js
@@ -221,6 +221,7 @@ class DocSearch {
                 !isLvl2 &&
                 (subcategory && subcategory !== "" && subcategory !== category);
             const isLvl0 = !isLvl1 && !isLvl2;
+            const version = hit.version;
 
             return {
                 isLvl0,
@@ -234,7 +235,8 @@ class DocSearch {
                 subcategory,
                 title: displayTitle,
                 text,
-                url
+                url,
+                version
             };
         });
     }

--- a/src/theme/SearchBar/algolia.css
+++ b/src/theme/SearchBar/algolia.css
@@ -457,6 +457,14 @@
   padding-right: 2px;
 }
 
+.algolia-autocomplete .algolia-docsearch-suggestion--version {
+  display: block;
+  font-size: 0.65em;
+  color: #a6aab1;
+  padding-top: 2px;
+  padding-right: 2px;
+}
+
 .algolia-autocomplete .algolia-docsearch-suggestion--no-results {
   width: 100%;
   padding: 8px 0;

--- a/src/theme/SearchBar/lunar-search.js
+++ b/src/theme/SearchBar/lunar-search.js
@@ -27,6 +27,7 @@ class LunrSearchAdapter {
                 lvl1: doc.type === 0 ? null : doc.title
             },
             url: doc.url,
+            version: doc.version,
             _snippetResult: formattedContent ? {
                 content: {
                     value: formattedContent,

--- a/src/theme/SearchBar/templates.js
+++ b/src/theme/SearchBar/templates.js
@@ -25,6 +25,7 @@ const templates = {
         <div class="${suggestionPrefix}--subcategory-inline">{{{subcategory}}}</div>
         <div class="${suggestionPrefix}--title">{{{title}}}</div>
         {{#text}}<div class="${suggestionPrefix}--text">{{{text}}}</div>{{/text}}
+        {{#version}}<div class="${suggestionPrefix}--version">{{version}}</div>{{/version}}
       </div>
       {{/isTextOrSubcategoryNonEmpty}}
     </div>


### PR DESCRIPTION
Hey! This change addresses issue #35. Suggestions now have version labels (when available) to enhancing the search experience for those who use versioned docs. You can disable the feature either by disabling the docusaurus versioning, or passing `'disableVersioning': true` directly in the plugin options. Hope y'all like it!

![image](https://user-images.githubusercontent.com/20016840/233495081-99341a04-45df-41ea-b288-feeb00f7b7d8.png)

![image](https://user-images.githubusercontent.com/20016840/233495306-aa538ae9-3e78-4237-aba2-38fd95e3ac6b.png)
