### PR TITLE
Further develop the `data-search-children` functionality

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+{ "singleQuote": true, "semi": false, "trailingComma": "none" }

--- a/README.md
+++ b/README.md
@@ -65,22 +65,32 @@ Supports all the language listed here https://github.com/MihaiValentin/lunr-lang
 
 ## Options available
 
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `languages` | `Array` | `['en']` | Language codes to use for stemming, Supports all the language listed here https://github.com/MihaiValentin/lunr-languages |
-| `indexBaseUrl` | `Boolean` | `false` | Base url will not indexed by default, if you want to index the base url set this option to `true` |
-| `excludeRoutes` | `Array` | `[]` | Exclude certain routes from the search |
-| `includeRoutes` | `Array` | `[]` | Include only specific routes for search |
-| `stopWords` | `Array` | `[]` | Add stop words(words that are exclude from search result) to the search index |
-| `excludeTags` | `Array` | `[]` | Exclude certain tags from the search |
-| `disableVersioning` | `Boolean` | `false` | Docs versions are displayed by default. If you want to hide it, set this plugin option to `true` |
+| Option              | Type      | Default  | Description                                                                                                               |
+| ------------------- | --------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `languages`         | `Array`   | `['en']` | Language codes to use for stemming, Supports all the language listed here https://github.com/MihaiValentin/lunr-languages |
+| `indexBaseUrl`      | `Boolean` | `false`  | Base url will not indexed by default, if you want to index the base url set this option to `true`                         |
+| `excludeRoutes`     | `Array`   | `[]`     | Exclude certain routes from the search                                                                                    |
+| `includeRoutes`     | `Array`   | `[]`     | Include only specific routes for search                                                                                   |
+| `stopWords`         | `Array`   | `[]`     | Add stop words(words that are exclude from search result) to the search index                                             |
+| `excludeTags`       | `Array`   | `[]`     | Exclude certain tags from the search                                                                                      |
+| `disableVersioning` | `Boolean` | `false`  | Docs versions are displayed by default. If you want to hide it, set this plugin option to `true`                          |
 
-## Using FrontMatter
-By default the library will search for heading only in the children of `.markdown` element. 
-If you are using a FrontMatter and you have headings that are encapsulated by other elements, such as divs, then add the attribute `data-search-children` to the elements having headings. 
-This also applies for all descendants of the wrapper with data-search-children.
+## Indexing non-direct children headings of `.markdown`
+By default, this library will only search for headings that are
+**direct children** of the `.markdown` element. 
 
-Check this [issue #115](https://github.com/praveenn77/docusaurus-lunr-search/issues/115) for more detail 
+If you would like to render content on a swizzled DocItem component,
+or any other built-in Docusaurus component, and want this library to
+**index the headings inside those custom elements even if they are not
+direct children of the `.markdown` element**, then add the attribute
+`data-search-children` to a parent element of the headings you want to
+index. 
+
+The `data-search-children` attribute will cause this library to look
+for all headings inside that element, including both direct and
+indirect children (E.g. 'grandchildren' nodes).
+
+Check this [issue #115](https://github.com/praveenn77/docusaurus-lunr-search/issues/115) for more details.
 
 
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Supports all the language listed here https://github.com/MihaiValentin/lunr-lang
 ## Using FrontMatter
 By default the library will search for heading only in the children of `.markdown` element. 
 If you are using a FrontMatter and you have headings that are encapsulated by other elements, such as divs, then add the attribute `data-search-children` to the elements having headings. 
+This also applies for all descendants of the wrapper with data-search-children.
 
 Check this [issue #115](https://github.com/praveenn77/docusaurus-lunr-search/issues/115) for more detail 
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ By default the library will search for heading only in the children of `.markdow
 If you are using a FrontMatter and you have headings that are encapsulated by other elements, such as divs, then add the attribute `data-search-children` to the elements having headings. 
 This also applies for all descendants of the wrapper with data-search-children.
 
-In this update, we have enhanced the `getSectionHeaders` function to provide better support for nested content structures. This modification allows the function to search for section headers not only in the immediate children of an element but also in its descendants. 
-
 Check this [issue #115](https://github.com/praveenn77/docusaurus-lunr-search/issues/115) for more detail 
 
 

--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ Supports all the language listed here https://github.com/MihaiValentin/lunr-lang
 By default, this library will only search for headings that are
 **direct children** of the `.markdown` element. 
 
-If you would like to render content on a swizzled DocItem component,
-or any other built-in Docusaurus component, and want this library to
-**index the headings inside those custom elements even if they are not
-direct children of the `.markdown` element**, then add the attribute
+If you would like to render content inside the `.markdown` element on
+a swizzled DocItem component, and want this library to **index the
+headings inside those custom elements even if they are not direct
+children of the `.markdown` element**, then add the attribute
 `data-search-children` to a parent element of the headings you want to
-index. 
+index.
 
 The `data-search-children` attribute will cause this library to look
 for all headings inside that element, including both direct and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docusaurus-lunr-search",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Offline search component for Docusaurus V2",
   "main": "src/index.js",
   "publishConfig": {

--- a/src/html-to-doc.js
+++ b/src/html-to-doc.js
@@ -10,7 +10,7 @@ const is = require('unist-util-is')
 const toVfile = require('to-vfile')
 
 const sectionHeaderTest = ({ tagName }) => ['h2', 'h3'].includes(tagName)
-const customSectionHeaderTest = ({ properties }) => properties && properties.dataSearchChildren
+const shouldIndexChildrenTest = ({ properties }) => properties && properties.dataSearchChildren
 
 // Build search data for a html
 function* scanDocuments({ path, url }) {
@@ -91,7 +91,7 @@ function getContent(element) {
   return toText(element).replace(/\s\s+/g, ' ').replace(/(\r\n|\n|\r)/gm, ' ').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
 }
 
-function getSectionHeaders(element, result = []) {
+function getSectionHeaders(element, result = [], shouldIndexChildren = false) {
   let currentSection = null
   let contentsAcc = ''
   const emitCurrent = () => {
@@ -112,14 +112,11 @@ function getSectionHeaders(element, result = []) {
         emitCurrent()
       }
       currentSection = node
-    } else if (is(node, customSectionHeaderTest)) {
-      getSectionHeaders(node, result)
+    } else if (is(node, shouldIndexChildrenTest)) {
+      getSectionHeaders(node, result, shouldIndexChildren)
     }
     else if (currentSection) {
       contentsAcc += getContent(node) + ' '
-    }
-    if (node.children) {
-      getSectionHeaders(node, result);
     }
   }
   if (currentSection) {

--- a/src/html-to-doc.js
+++ b/src/html-to-doc.js
@@ -112,7 +112,7 @@ function getSectionHeaders(element, result = [], shouldIndexChildren = false) {
         emitCurrent()
       }
       currentSection = node
-    } else if (is(node, shouldIndexChildrenTest) || (shouldIndexChildren && node.children.length)) {
+    } else if (is(node, shouldIndexChildrenTest) || (shouldIndexChildren && node.children)) {
       getSectionHeaders(node, result, true)
     }
     else if (currentSection) {

--- a/src/html-to-doc.js
+++ b/src/html-to-doc.js
@@ -112,8 +112,8 @@ function getSectionHeaders(element, result = [], shouldIndexChildren = false) {
         emitCurrent()
       }
       currentSection = node
-    } else if (is(node, shouldIndexChildrenTest)) {
-      getSectionHeaders(node, result, shouldIndexChildren)
+    } else if (is(node, shouldIndexChildrenTest) || (shouldIndexChildren && node.children.length)) {
+      getSectionHeaders(node, result, true)
     }
     else if (currentSection) {
       contentsAcc += getContent(node) + ' '

--- a/src/html-to-doc.js
+++ b/src/html-to-doc.js
@@ -22,9 +22,7 @@ function* scanDocuments({ path, url }) {
     return
   }
 
-  const hast = unified()
-    .use(parse, { emitParseErrors: false })
-    .parse(vfile)
+  const hast = unified().use(parse, { emitParseErrors: false }).parse(vfile)
 
   const article = select('article', hast)
   if (!article) {
@@ -42,22 +40,26 @@ function* scanDocuments({ path, url }) {
   const pageTitle = toText(pageTitleElement)
   const sectionHeaders = getSectionHeaders(markdown)
 
-  const keywords = selectAll('meta[name="keywords"]', hast).reduce((acc, metaNode) => {
-    if (metaNode.properties.content) {
-      return acc.concat(metaNode.properties.content.replace(/,/g, ' '))
-    }
-    return acc
-  }, []).join(' ')
+  const keywords = selectAll('meta[name="keywords"]', hast)
+    .reduce((acc, metaNode) => {
+      if (metaNode.properties.content) {
+        return acc.concat(metaNode.properties.content.replace(/,/g, ' '))
+      }
+      return acc
+    }, [])
+    .join(' ')
 
-  let version = null;
+  let version = null
   if (workerData.loadedVersions) {
-    const docsearchVersionElement = select('meta[name="docsearch:version"]', hast);
+    const docsearchVersionElement = select(
+      'meta[name="docsearch:version"]',
+      hast
+    )
 
     version = docsearchVersionElement
       ? workerData.loadedVersions[docsearchVersionElement.properties.content]
-      : null;
+      : null
   }
-
 
   yield {
     title: pageTitle,
@@ -67,11 +69,11 @@ function* scanDocuments({ path, url }) {
     // If there is no sections then push the complete content under page title
     content: sectionHeaders.length === 0 ? getContent(markdown) : '',
     keywords,
-    version,
+    version
   }
 
   for (const sectionDesc of sectionHeaders) {
-    const { title, content, ref, tagName } = sectionDesc;
+    const { title, content, ref, tagName } = sectionDesc
     yield {
       title,
       type: 1,
@@ -85,7 +87,13 @@ function* scanDocuments({ path, url }) {
 }
 
 function getContent(element) {
-  return toText(element).replace(/\s\s+/g, ' ').replace(/(\r\n|\n|\r)/gm, ' ').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+  return toText(element)
+    .replace(/\s\s+/g, ' ')
+    .replace(/(\r\n|\n|\r)/gm, ' ')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
 }
 
 function getSectionHeaders(element) {
@@ -112,7 +120,7 @@ function getSectionHeaders(element) {
   ) {
     let currentHeadingNode = parentHeadingNode
 
-  for (const node of element.children) {
+    for (const node of element.children) {
       if (is(node, isHeadingNodeTest)) {
         trackHeadingNode(node)
         currentHeadingNode = node
@@ -132,7 +140,7 @@ function getSectionHeaders(element) {
     return {
       ...rest,
       content: node['_indexed-content']
-  }
+    }
   })
 }
 

--- a/src/html-to-doc.js
+++ b/src/html-to-doc.js
@@ -118,6 +118,9 @@ function getSectionHeaders(element, result = []) {
     else if (currentSection) {
       contentsAcc += getContent(node) + ' '
     }
+    if (node.children) {
+      getSectionHeaders(node, result);
+    }
   }
   if (currentSection) {
     emitCurrent()


### PR DESCRIPTION
This PR aims at improving the features added in [this commit](https://github.com/praveenn77/docusaurus-lunr-search/commit/71ed505ea63274e72775bcf41e6d2a206a0aa7dc).

The initial implementation worked by indexing only the immediate children of the element that had the `data-search-children` attribute. This PR builds on top of that behavior, and now indexes all heading elements under that element with the attribute, not mattering if they are direct or indirect children (E.g. children/grandchildren).

Alongside the code that handles the main purpose of this PR, this PR contains:
* `README.md` updates.
* Auto-formatting of `README.md` table.
* Codebase version bump (now 2.4.3).
* Addition of a `.prettierrc` file to enforce more consistent styling across development environments.
* A minor refactor of the `html-to-doc.js` file, more specifically, a refactor of the `getSectionHeaders` function.
* Auto-formatting of `html-to-doc.js` file.