### PR TITLE
Avoid "Cannot read properties of undefined (reading 'length')"

### DIFF
--- a/src/theme/SearchBar/index.jsx
+++ b/src/theme/SearchBar/index.jsx
@@ -71,7 +71,7 @@ const Search = props => {
         import("./algolia.css")
       ]).then(([searchDocFile, searchIndex, { default: DocSearch }]) => {
         const { searchDocs, options } = searchDocFile;
-        if (searchDocs.length === 0) {
+        if (!searchDocs || searchDocs.length === 0) {
           return;
         }
         initAlgolia(searchDocs, searchIndex, DocSearch, options);


### PR DESCRIPTION
On a fresh install of the latest docusaurus (v2.4.3) and docusaurus-lunr-search (v3.0.0) the following error is thrown in non-production mode:

```jsx
TypeError: Cannot read properties of undefined (reading 'length')
    at eval (webpack-internal:///./node_modules/docusaurus-lunr-search/src/theme/SearchBar/index.jsx:17:1504)
```

![docusaurus-lunr-search-runtime-error](https://github.com/praveenn77/docusaurus-lunr-search/assets/114563/afec8fc3-da85-4284-bcef-bc2a8b44c377)


I believe this is caused by the changes in 426e3131d7, where in `development` mode the `searchDocFile` (from `getSearchDoc()`) is just an empty array.