### PR TITLE
feat: Introduce option maxHits: Show more or less than the default 5 hits when searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ Supports all the language listed here https://github.com/MihaiValentin/lunr-lang
 | `excludeTags`       | `Array`   | `[]`     | Exclude certain tags from the search      
 | `highlightResult`   | `Boolean` | `false`  | Enable it to highlight the searched word in the result page. Used `mark.js` for highlighting. <br /> You can customize the highlight color using css <br /> ``` mark  { background-color: red !important; color: green !important }```                                                                                |
 | `disableVersioning` | `Boolean` | `false`  | Docs versions are displayed by default. If you want to hide it, set this plugin option to `true`                          |
-| `assetUrl`     | `string`   | `\`     | Url from which the generated search doc files to be loaded, check [issue #122](https://github.com/praveenn77/docusaurus-lunr-search/issues/122)
+| `assetUrl`     | `string`   | `\`     | Url from which the generated search doc files to be loaded, check [issue #122](https://github.com/praveenn77/docusaurus-lunr-search/issues/122) |
+| `maxHits`           | `string`  | `5`      | Maximum number of hits shown |
 
 ## Indexing non-direct children headings of `.markdown`
 By default, this library will only search for headings that are

--- a/src/theme/SearchBar/DocSearch.js
+++ b/src/theme/SearchBar/DocSearch.js
@@ -22,7 +22,8 @@ class DocSearch {
         queryHook = false,
         handleSelected = false,
         enhancedSearchInput = false,
-        layout = "column"
+        layout = "column",
+        maxHits = 5
     }) {
         this.input = DocSearch.getInputFromSelector(inputSelector);
         this.queryDataCallback = queryDataCallback || null;
@@ -46,7 +47,7 @@ class DocSearch {
 
         this.isSimpleLayout = layout === "simple";
 
-        this.client = new LunrSearchAdapter(searchDocs, searchIndex, baseUrl);
+        this.client = new LunrSearchAdapter(searchDocs, searchIndex, baseUrl, maxHits);
 
         if (enhancedSearchInput) {
             this.input = DocSearch.injectSearchBox(this.input);

--- a/src/theme/SearchBar/index.jsx
+++ b/src/theme/SearchBar/index.jsx
@@ -51,7 +51,8 @@ const Search = props => {
         history.push(url, {
           highlightState: { wordToHighlight },
         });
-      }
+      },
+      maxHits: options.maxHits
     });
   };
 

--- a/src/theme/SearchBar/lunar-search.js
+++ b/src/theme/SearchBar/lunar-search.js
@@ -9,10 +9,11 @@ import lunr from "@generated/lunr.client";
 lunr.tokenizer.separator = /[\s\-/]+/;
 
 class LunrSearchAdapter {
-    constructor(searchDocs, searchIndex, baseUrl = '/') {
+    constructor(searchDocs, searchIndex, baseUrl = '/', maxHits) {
         this.searchDocs = searchDocs;
         this.lunrIndex = lunr.Index.load(searchIndex);
         this.baseUrl = baseUrl;
+        this.maxHits = maxHits;
     }
 
     getLunrResult(input) {
@@ -123,7 +124,7 @@ class LunrSearchAdapter {
         return new Promise((resolve, rej) => {
             const results = this.getLunrResult(input);
             const hits = [];
-            results.length > 5 && (results.length = 5);
+            results.length > this.maxHits && (results.length = this.maxHits);
             this.titleHitsRes = []
             this.contentHitsRes = []
             results.forEach(result => {
@@ -146,7 +147,7 @@ class LunrSearchAdapter {
                     }
                 }
             });
-            hits.length > 5 && (hits.length = 5);
+            hits.length > this.maxHits && (hits.length = this.maxHits);
             resolve(hits);
         });
     }


### PR DESCRIPTION
Introduce a new option `maxHits`. Before you had to go with the default `5` hits which was sometimes too few.

Now you can go with `7`.

### Usage

```
[
      require.resolve('docusaurus-lunr-search'),
      {
        maxHits: 7
      }
```