### PR TITLE
Fix: Index html file when multiple article elements present in file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .npmrc
 node_modules
+.DS_Store

--- a/src/html-to-doc.js
+++ b/src/html-to-doc.js
@@ -9,6 +9,16 @@ const toText = require('hast-util-to-text')
 const is = require('unist-util-is')
 const toVfile = require('to-vfile')
 
+function findArticleWithMarkdown(articles) {
+  for (let i = 0; i < articles.length; i++) {
+    markdown = select('.markdown', articles[i])
+    if (markdown) {
+      return [markdown, articles[i]];
+    }
+  }
+  return [null, null];
+}
+
 // Build search data for a html
 function* scanDocuments({ path, url }) {
   let vfile
@@ -24,11 +34,12 @@ function* scanDocuments({ path, url }) {
 
   const hast = unified().use(parse, { emitParseErrors: false }).parse(vfile)
 
-  const article = select('article', hast)
-  if (!article) {
+  const articles = selectAll('article', hast)
+  if (!articles) {
     return
   }
-  const markdown = select('.markdown', article)
+
+  const [markdown, article] = findArticleWithMarkdown(articles)
   if (!markdown) {
     return
   }


### PR DESCRIPTION
I think this may resolve issues #126 and #134. 

We observed the same behavior with imports discussed in #126. In our case, the issue was caused by the imports creating additional article elements in the compiled html files. We found during indexing, that workers search through the html files to find the first article element in each file and indexes the article element if it has an element associated with the `markdown` class. So markdown pages with imports could be skipped during indexing as the article element with the markdown class is not guaranteed to be the first article element in the compiled html file. 

This PR allows the workers to search through all articles in each html file to find the article associated the `markdown` class.  