### PR TITLE
Fix warnings about duplicate lunr.Pipeline.registerFunction() calls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const utils = require('./utils')
 
 module.exports = function (context, options) {
   options = options || {};
-  let languages
+  let languages = undefined;
 
   const guid = String(Date.now())
   const fileNames = {
@@ -24,9 +24,13 @@ module.exports = function (context, options) {
       return path.resolve(__dirname, './theme');
     },
     configureWebpack(config) {
-      // Multilingual issue fix
-      const generatedFilesDir = config.resolve.alias['@generated']
-      languages = utils.generateLunrClientJS(generatedFilesDir, options.languages);
+      // Docusaurus invokes configureWebpack() twice, for client and server; however generateLunrClientJS()
+      // is a global configuration.
+      if (languages === undefined) {
+        // Multilingual issue fix
+        const generatedFilesDir = config.resolve.alias['@generated']
+        languages = utils.generateLunrClientJS(generatedFilesDir, options.languages);
+      }
       return {};
     },
     async contentLoaded({ actions }) {


### PR DESCRIPTION
When invoking `docusaurus build`, Lunr reports warnings such as:

```
Overwriting existing registered function: trimmer-zh
Overwriting existing registered function: stemmer-zh
Overwriting existing registered function: stopWordFilter-zh
Overwriting existing registered function: lunr-multi-trimmer-en-zh
```

Because these warnings are printed to STDERR, they are interpreted as errors by our build system.

## Why Lunr is complaining

Docusaurus calls the [configureWebpack](https://docusaurus.io/docs/api/plugin-methods/lifecycle-apis#configureWebpack) hook twice, once for the client and once for the server (static SSR content):

```js
    plugins.forEach((plugin) => {
        const { configureWebpack, configurePostCss } = plugin;
        if (configurePostCss) {
            clientConfig = (0, utils_2.applyConfigurePostCss)(configurePostCss.bind(plugin), clientConfig);
        }
        if (configureWebpack) {
            clientConfig = (0, utils_2.applyConfigureWebpack)(configureWebpack.bind(plugin), // The plugin lifecycle may reference `this`.
            clientConfig, false, props.siteConfig.webpack?.jsLoader, plugin.content);
            serverConfig = (0, utils_2.applyConfigureWebpack)(configureWebpack.bind(plugin), // The plugin lifecycle may reference `this`.
            serverConfig, true, props.siteConfig.webpack?.jsLoader, plugin.content);
        }
    });
```

As a result, this `docusaurus-lunr-search` code is invoked twice:
```js
    configureWebpack(config) {
      // Multilingual issue fix
      const generatedFilesDir = config.resolve.alias['@generated']
      languages = utils.generateLunrClientJS(generatedFilesDir, options.languages);
      return {};
    },
```
...which causes `lunr-languages` to invoke `registerFunction()` twice for each function, because `lunr.Pipeline` is a global registry:

```js
lunr.Pipeline.registerFunction(lunr.zh.trimmer, 'trimmer-zh');
```

This is not the intended API usage, thus a warning is printed:

```js
/**
 * Register a function with the pipeline.
 *
 * Functions that are used in the pipeline should be registered if the pipeline
 * needs to be serialised, or a serialised pipeline needs to be loaded.
 *
 * Registering a function does not add it to a pipeline, functions must still be
 * added to instances of the pipeline for them to be used when running a pipeline.
 *
 * @param {lunr.PipelineFunction} fn - The function to check for.
 * @param {String} label - The label to register this function with
 */
lunr.Pipeline.registerFunction = function (fn, label) {
  if (label in this.registeredFunctions) {
    lunr.utils.warn('Overwriting existing registered function: ' + label)
  }

  fn.label = label
  lunr.Pipeline.registeredFunctions[fn.label] = fn
}
```

The issue is easily fixed by invoking `utils.generateLunrClientJS()` only once.

## Testing

I did a clean build of our website before/after the fix from this PR.  Then I compared the output files `**/lunr-index*.json`  and `**/search-doc*.json`.  I also compared Docusaurus outputs.

The outputs are not identical because certain chunks are emitted in nondeterministic order, and also filenames include Webpack hashes. After normalizing/sorting the file content to account for these differences, I confirmed that the outputs are equivalent.

@chengcyber