### PR TITLE
Expose Lunr field attributes to docusaurus config

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ Supports all the language listed here https://github.com/MihaiValentin/lunr-lang
 | `disableVersioning` | `Boolean` | `false`  | Docs versions are displayed by default. If you want to hide it, set this plugin option to `true`                          |
 | `assetUrl`     | `string`   | `\`     | Url from which the generated search doc files to be loaded, check [issue #122](https://github.com/praveenn77/docusaurus-lunr-search/issues/122) |
 | `maxHits`           | `string`  | `5`      | Maximum number of hits shown |
+| `fields`            | `object`  | `{}`      | Lunr field definitions, allows "boosting" priority for different sources of keywords (e.g. title, content, keywords) |
+
+### Options to configure Lunr fields
+The `fields` config property is passed into Lunr directly as [field attributes](https://lunrjs.com/docs/lunr.Builder.html#field), and can be used to configure the relative priority of different field types (e.g. title, content, keywords). 
+
+docusaurus-lunr-search sets the default value for fields to:
+
+```javascript
+{ 
+  title: { boost: 200 },
+  content: { boost: 2 },
+  keywords: { boost: 100 }
+}
+```
 
 ## Indexing non-direct children headings of `.markdown`
 By default, this library will only search for headings that are

--- a/src/index.js
+++ b/src/index.js
@@ -46,15 +46,23 @@ module.exports = function (context, options) {
       if (meta.excludedCount) {
         console.log(`docusaurus-lunr-search:: ${meta.excludedCount} documents were excluded from the search by excludeRoutes config`)
       }
+      
+      // Expose Lunr's fields configuration through docusaurus options.
+      // Fields are used to configure how Lunr treats different sources of search terms.
+      // This allows a user to boost the importance of certain fields over others.
+      const fields = {
+        title: { boost: 200, ...options.fields?.title },
+        content: { boost: 2, ...options.fields?.content },
+        keywords: { boost: 100, ...options.fields?.keywords },
+      };
+
       const searchDocuments = []
       const lunrBuilder = lunr(function (builder) {
         if (languages) {
           this.use(languages)
         }
         this.ref('id')
-        this.field('title', { boost: 200 })
-        this.field('content', { boost: 2 })
-        this.field('keywords', { boost: 100 })
+        Object.entries(fields).forEach(([key, value]) => this.field(key, value));
         this.metadataWhitelist = ['position']
 
         const { build } = builder


### PR DESCRIPTION
Exposes Lunr's field attribute configuration via docusaurus config. This allows users to configure the fields that are indexed by Lunr, and their relative priority.

These fields map directly to Lunr's field configuration, and are treated opaquely, so any additional features supported by Lunr (now or in the future) can be configured via this option, without any changes to docusaurus-lunr-search.

Also added documentation for the new `fields` configuration option.