### PR TITLE
Fix accessibility violation in expand searchbar button

### DIFF
--- a/src/theme/SearchBar/index.jsx
+++ b/src/theme/SearchBar/index.jsx
@@ -97,6 +97,17 @@ const Search = props => {
     [props.isSearchBarExpanded]
   );
 
+  const handleKeyDown = useCallback(
+    e => {
+      // Only trigger for Enter (13) or Space (32) key presses
+      if (e.keyCode === 13 || e.keyCode === 32) {
+        e.preventDefault();
+        toggleSearchIconClick(e);
+      }
+    },
+    [toggleSearchIconClick]
+  );
+
   let placeholder
   if (isBrowser) {
     loadAlgolia();
@@ -120,7 +131,7 @@ const Search = props => {
           "search-icon-hidden": props.isSearchBarExpanded
         })}
         onClick={toggleSearchIconClick}
-        onKeyDown={toggleSearchIconClick}
+        onKeyDown={handleKeyDown}
         tabIndex={0}
       />
       <input


### PR DESCRIPTION
There is a WCAG accessibility violation: A role=button element that captures keyDown should only act on enter and space, according to WCAG standards, but the expand searchbar button captures all keystroke. Therefore, I can tab past the search bar, but can't shift-tab backwards because I get stuck on the button.

This PR fixes this violation by making the expand button only activate on enter and space, according to WCAG standards.