### PR TITLE
feat: add maxThreads option for worker thread count

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Supports all the language listed here https://github.com/MihaiValentin/lunr-lang
 | `assetUrl`     | `string`   | `\`     | Url from which the generated search doc files to be loaded, check [issue #122](https://github.com/praveenn77/docusaurus-lunr-search/issues/122) |
 | `maxHits`           | `string`  | `5`      | Maximum number of hits shown |
 | `fields`            | `object`  | `{}`      | Lunr field definitions, allows "boosting" priority for different sources of keywords (e.g. title, content, keywords) |
+| `maxThreads`        | `number`  | `os.cpus().length` | Maximum number of worker threads for indexing. Useful in containerized environments where `os.cpus()` returns the host's CPU count instead of the container's limit |
 
 ### Options to configure Lunr fields
 The `fields` config property is passed into Lunr directly as [field attributes](https://lunrjs.com/docs/lunr.Builder.html#field), and can be used to configure the relative priority of different field types (e.g. title, content, keywords). 

--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,7 @@ module.exports = function (context, options) {
         searchDocuments.push(d);
       }
 
-      const indexedDocuments = await buildSearchData(files, addToSearchData, loadedVersions)
+      const indexedDocuments = await buildSearchData(files, addToSearchData, loadedVersions, options)
       const lunrIndex = lunrBuilder.build()
       console.timeEnd('docusaurus-lunr-search:: Indexing time')
       console.log(`docusaurus-lunr-search:: indexed ${indexedDocuments} documents out of ${files.length}`)
@@ -132,12 +132,15 @@ module.exports = function (context, options) {
   };
 };
 
-function buildSearchData(files, addToSearchData, loadedVersions) {
+function buildSearchData(files, addToSearchData, loadedVersions, options) {
   if (!files.length) {
     return Promise.resolve()
   }
   let activeWorkersCount = 0
-  const workerCount = Math.max(2, os.cpus().length)
+  // Use maxThreads from options if provided, otherwise fall back to CPU count.
+  // This is useful in containerized environments where os.cpus() returns the host's
+  // CPU count rather than the container's CPU limit.
+  const workerCount = Math.max(2, options.maxThreads || os.cpus().length)
 
   console.log(`docusaurus-lunr-search:: Start scanning documents in ${Math.min(workerCount, files.length)} threads`)
   const gauge = new Guage()


### PR DESCRIPTION
In containerized environments, os.cpus() returns the host machine's CPU count rather than the container's CPU limit. This can cause issues when running builds in Docker containers with limited CPU allocations.

This adds a maxThreads option that allows users to explicitly set the maximum number of worker threads used during indexing. If not specified, it falls back to the existing behavior of using os.cpus().length.